### PR TITLE
Update to latest lilypond to fix -o option error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y wget
 
-RUN wget https://lilypond.org/download/binaries/linux-64/lilypond-2.20.0-1.linux-64.sh
+RUN wget https://lilypond.org/download/binaries/linux-64/lilypond-2.21.5-1.linux-64.sh
 
-RUN sh lilypond-2.20.0-1.linux-64.sh
+RUN sh lilypond-2.21.5-1.linux-64.sh


### PR DESCRIPTION
Hi,

When running the `lilypond` command with `-o` option to specify outdir dir for lilypond, you get an error. As far as I can tell this is a bug with the v2.20 of lilypond which is fixed in the latest version.

This PR just updates to the latest version of lilypond.

Thanks,
Sam